### PR TITLE
近距離の融合遺伝子を検出するためのフィルタの実装(修正版)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ For STAR, our software uses the chimeric sam file
 {output_prefix}.Chimeric.out.sam
 ```
 
+Optionally, you can specify the following files to enable further analysis (Note that
+the aligned bam must be sorted by coordinate):
+
+```
+{output_prefix}.SJ.out.tab
+{output_prefix}.Aligned.sortedByCoord.out.bam
+```
+
 For MapSplice2, our software uses the read alignment file
 ```
 alignments.sam (bam)
@@ -73,6 +81,8 @@ fusionfusion [-h] [--version] [--star star.Chimeric.out.sam]
                   [--min_allowed_contig_match_diff MIN_ALLOWED_CONTIG_MATCH_DIFF]
                   [--check_contig_size_other_breakpoint CHECK_CONTIG_SIZE_OTHER_BREAKPOINT]
                   [--filter_same_gene]
+                  [--star_sj_tab star.SJ.out.tab]
+                  [--star_aligned_bam star.Aligned.sortedByCoord.out.bam]
 ```
 At least one of --star, --ms2, --th2 arguments should be specified.
 The arguments of --out and --reference_genome are mandatory. 

--- a/fusionfusion/arg_parser.py
+++ b/fusionfusion/arg_parser.py
@@ -16,6 +16,12 @@ def create_parser():
     parser.add_argument("--star", metavar = "star.Chimeric.out.sam", default = None, type = str,
                         help = "the path to the chimeric sam file by STAR")
 
+    parser.add_argument("--star_sj_tab", metavar="star.SJ.out.tab", default=None, type=str,
+                        help="the path to the SJ.out.tab file by STAR")
+
+    parser.add_argument("--star_aligned_bam", metavar="star.Aligned.sortedByCoord.out.bam", default=None, type=str,
+                        help="the path to the aligned bam file by STAR (which must be sorted by coordinate)")
+
     parser.add_argument("--ms2", metavar = "ms2.bam", default = None, type = str,
                         help = "the path to the bam file by Map splice2")
 
@@ -87,4 +93,3 @@ def create_parser():
 
 
     return parser
-

--- a/fusionfusion/parseJunctionInfo.py
+++ b/fusionfusion/parseJunctionInfo.py
@@ -343,7 +343,7 @@ def parseJuncInfo_th2(inputFilePath, outputFilePath):
     hOUT.close()
 
 
-def getFusInfo_STAR(juncLine):
+def getFusInfo_STAR(juncLine, source=None):
 
     # abnormal_insert_size = config.param_conf.getint("parse_condition", "abnormal_insert_size")
     # min_major_clip_size = config.param_conf.getint("parse_condition", "min_major_clip_size")
@@ -409,7 +409,11 @@ def getFusInfo_STAR(juncLine):
             coverRegion_primary = cigar_utils.getCoverRegion(F[2], F[3], F[5])
             readLength_primary = len(F[9])
             endPos_primary = cigar_utils.getEndPos(pos_primary, F[5])
-            readID_primary = F[0] + ("/1" if flags[6] == "1" else "/2")
+            readID_primary = "{qname}/{read}{suffix}".format(
+                qname=F[0],
+                read=(1 if flags[6] == "1" else 2),
+                suffix=("@" + source if source else "")
+            )
 
             tempMatch = cigarSRe_right.search(F[5])
             if tempMatch is not None: right_clipping_primary = int(tempMatch.group(1))
@@ -574,7 +578,7 @@ def getFusInfo_STAR(juncLine):
 
 
 
-def parseJuncInfo_STAR(inputFilePath, outputFilePath):
+def parseJuncInfo_STAR(inputFilePath, outputFilePath, source=None):
 
      
     hIN = open(inputFilePath, 'r')
@@ -589,7 +593,7 @@ def parseJuncInfo_STAR(inputFilePath, outputFilePath):
 
         if tempID != F[0]:
             if tempID != "" and len(tempLine) == 3:
-                tempFusInfo = getFusInfo_STAR(tempLine)
+                tempFusInfo = getFusInfo_STAR(tempLine, source)
                 if tempFusInfo is not None:
                     print(tempFusInfo, file = hOUT)
 
@@ -602,7 +606,7 @@ def parseJuncInfo_STAR(inputFilePath, outputFilePath):
 
 
     if tempID != "" and len(tempLine) == 3:
-        tempFusInfo = getFusInfo_STAR(tempLine)
+        tempFusInfo = getFusInfo_STAR(tempLine, source)
         if tempFusInfo is not None:
             print(tempFusInfo, file = hOUT)
 

--- a/fusionfusion/seq_utils.py
+++ b/fusionfusion/seq_utils.py
@@ -7,7 +7,15 @@ def getSeq(reference, region_tuple):
 
     seq = ""    
     for reg in region_tuple_sorted:
-        for line in pysam.faidx(reference, reg[0] + ":" + str(reg[1]) + "-" + str(reg[2]), split_lines=True):
+        lines = []
+        try:
+            lines = pysam.faidx(reference, reg[0] + ":" + str(reg[1]) + "-" + str(reg[2]), split_lines=True)
+        except pysam.utils.SamtoolsError:
+            # With latest versions of pysam, faidx raises an error if it gets fed with
+            # a contradictory range (such as `chr:start-end` where start > end).
+            # This try-except statement is for handling such cases.
+            pass
+        for line in lines:
             if line[0] == ">": continue
             seq += line
 

--- a/fusionfusion/short_range_chimera_filter.py
+++ b/fusionfusion/short_range_chimera_filter.py
@@ -1,0 +1,125 @@
+import collections
+import copy
+import itertools
+import pysam
+
+from . import annotationFunction
+
+class ShortRangeChimeraFilter:
+    def __init__(self, ref_gene_tb, ens_gene_tb):
+        self.ref_gene_tb = ref_gene_tb
+        self.ens_gene_tb = ens_gene_tb
+        self.interval = 500
+
+    def run(self, splicing_file, bam_file, output_file):
+        with open(splicing_file) as splicing_reader, \
+             pysam.AlignmentFile(bam_file, 'r') as bam_reader, \
+             pysam.AlignmentFile(output_file, 'w', header=bam_reader.header) as sam_writer:
+            for chr, start, end in self.load_splicing_junctions(splicing_reader):
+                pair_alns = collections.defaultdict(set)
+                for aln in self.load_alignments(bam_reader, chr, start, end):
+                    locus = (aln.reference_name, aln.reference_start)
+                    entry = (aln.query_name, aln.is_read1)
+                    if entry in pair_alns[locus]:
+                        self.write_alignment(sam_writer, aln, chr, start, end)
+                        pair_alns[locus].remove(entry)
+                    else:
+                        aln1, aln2 = self.split_alignment(aln, start)
+                        self.write_alignment(sam_writer, aln1, chr, start, end)
+                        self.write_alignment(sam_writer, aln2, chr, start, end)
+                        next_locus = (aln.next_reference_name, aln.next_reference_start)
+                        next_entry = (aln.query_name, not aln.is_read1)
+                        pair_alns[next_locus].add(next_entry)
+                # fetch and write pair reads
+                for aln in self.load_pair_alignments(bam_reader, pair_alns):
+                    self.write_alignment(sam_writer, aln, chr, start, end)
+
+    def write_alignment(self, sam_writer, aln, chr, start, end):
+        # Strip tags since they are unnecessary for succeeding processes
+        aln.set_tags([])
+        aln.query_name += '_{}:{}-{}'.format(chr, start, end+1)
+        sam_writer.write(aln)
+
+    def get_genes_at(self, chr, pos):
+        return set(annotationFunction.get_gene_info(chr, pos, self.ref_gene_tb, self.ens_gene_tb))
+
+    def load_splicing_junctions(self, splicing_reader):
+        for line in splicing_reader:
+            chr, start, end = line.split('\t')[:3]
+            start_genes = self.get_genes_at(chr, start)
+            end_genes = self.get_genes_at(chr, end)
+            if not(start_genes.intersection(end_genes)):
+                yield (chr, int(start)-1, int(end))
+
+    def load_alignments(self, bam_reader, chr, start, end):
+        def pairwise(it):
+            it1, it2 = itertools.tee(it)
+            next(it2, None)
+            return zip(it1, it2)
+
+        for aln in bam_reader.fetch(chr, start, start+1):
+            if not aln.is_proper_pair or aln.is_secondary: continue
+
+            for (_, curr_end), (next_start, _) in pairwise(aln.get_blocks()):
+                if curr_end == start and next_start == end:
+                    break
+            else:
+                continue
+            yield aln
+
+    def load_pair_alignments(self, bam_reader, pair_alns):
+        def chunked(alns, interval):
+            chrom = start = end = None
+            entries = set()
+            for (chr, pos), es in sorted(alns.items(), key=lambda x: x[0]):
+                if chrom == chr and pos <= start + interval:
+                    end = pos
+                    entries.update(es)
+                    continue
+                if entries:
+                    yield chrom, start, end, entries
+                chrom = chr
+                start = end = pos
+                entries = set(es)
+            if entries:
+                yield chrom, start, end, entries
+
+        for (chr, start, end, entries) in chunked(pair_alns, self.interval):
+            for aln in bam_reader.fetch(chr, start, end + 1):
+                locus = (aln.reference_name, aln.reference_start)
+                entry = (aln.query_name, aln.is_read1)
+                if not aln.is_secondary and entry in entries:
+                    yield aln
+
+    def split_alignment(self, aln, splicing_start):
+        elems = aln.cigartuples
+        blocks = aln.get_blocks()
+
+        elem_idx = 0
+        block_idx = 0
+        for op, len in elems:
+            if op == 0:
+                _, block_end = blocks[block_idx]
+                if block_end == splicing_start: break
+                block_idx += 1
+            elem_idx += 1
+
+        elems1 = elems[:elem_idx+1]
+        elems2 = list(itertools.dropwhile(lambda elem: elem[0] != 0, elems[elem_idx+1:]))
+        count_bases = lambda ops, elems: sum(e[1] for e in elems if e[0] in ops)
+
+        aln1 = copy.copy(aln)
+        aln2 = copy.copy(aln)
+        prim_flag, suppl_flag = aln.flag & ~0x100, aln.flag | 0x100
+        # Consider alignment with more matched bases as primary and the other as supplementary
+        if count_bases({0}, elems1) >= count_bases({0}, elems2):
+            aln1.flag, aln2.flag = prim_flag, suppl_flag
+        else:
+            aln1.flag, aln2.flag = suppl_flag, prim_flag
+        aln2.reference_start = blocks[block_idx+1][0]
+        # To reset CIGAR (and related properties), .cigartuples must be set to None first
+        aln1.cigartuples = None; aln1.cigartuples = elems1 + [(4, count_bases({0, 1, 4}, elems2))]
+        aln2.cigartuples = None; aln2.cigartuples = [(4, count_bases({0, 1, 4}, elems1))] + elems2
+        aln1.template_length, aln2.template_length = \
+            (aln.template_length, 0) if aln.template_length >= 0 else (0, aln.template_length)
+        return (aln1, aln2)


### PR DESCRIPTION
このプルリクエストは、 #12 の近距離の融合遺伝子を検出するフィルタの修正版を実装しています。

#12 からの主な変更点は以下の2つです：

- `—star_sj_tab`および`—star_aligned_bam`という2つのコマンドラインオプションを新たに追加し、それぞれSTARの解析結果に含まれる`SJ.out.tab`および `Aligned.sortedByCoord.out.bam`のパスを指定するようにしました
- fusionfusionの結果ファイルとして新たに`fusion_fusion.result.traced.txt`というファイルを追加し、fusionfusionがレポートする各変異について、`Chimeric.out.sam`と`SJ.out.tab`のどちらに由来するものかを示す情報を付加した出力をするようにしました

それ以外の点について以前(#12)の実装から変更はありません。特に、[`ShortRangeChimeraFilter`](https://github.com/chrovis-genomon/fusionfusion/blob/dbd2e50dd3950d5cac0c84d9b06e373194b9d1d9/fusionfusion/short_range_chimera_filter.py#L8)のコードは以前のものとまったく同一です。

上記変更の1点目については、既存の`—star`オプションとは別に新たなオプションを追加することで、`—star_sj_tab`および`—star_aligned_bam`の両オプションを指定しない限り従来同様`Chimeric.out.sam`のみで解析できるようにするための変更です。

2点目について、仕様と具体的な処理の詳細を以下で説明します。

以下の図は今回の変更を含めたfusionfusionで使われるファイル形式の処理フローを示しています。図中の矢印(たとえば、`A → B`)はファイル`B`がファイル`A`から生成されることを表わしています。赤線で囲まれた四角が今回追加したファイルを表わしています。

![](https://user-images.githubusercontent.com/27441/111404186-ace7d380-8711-11eb-8f9c-686b87428b92.png)

今回追加した`fusion_fusion.result.traced.txt`は、既存の結果ファイルである`fusion_fusion.result.txt`とほぼ同じ形式で、一番右のカラムとして各行の変異が`Chimeric.out.sam`と`SJ.out.tab`のどちらに由来するものかを示す値(これを各変異の「ソース(source)」と呼んでいます)が追加されています。

ソースとしてありうる値とその意味は以下のとおりです：

| ソース値 | 意味 |
|:---------|:-----|
| `Chimeric` | `Chimeric.out.sam`に由来する変異 |
| `SJ` | `SJ.out.tab`に由来する変異 |
| `SJ,Chimeric` | `SJ.out.tab`および`Chimeric.out.sam`のどちらにも由来する変異 |
| `---` | 不明(STAR以外のアライナーと組み合わせて使った場合にそのアライナーに由来して報告された変異) |

この変更では、`fusion_fusion.result.traced.txt`を生成するために必要な中間ファイルとして`star.chimeric.trace.txt`というもう1つのファイルを新たに追加しています。`star.chimeric.trace.txt`の形式は以下のようになっています：

```
<chr1> <pos1> <strand1> <chr2> <pos2> <strand2> <inserted seq> <source>
```

1〜7カラム目(`<chr1>`〜`<inserted seq>`)までは`fusion_fusion.result.txt`等の1〜7カラム目までと同じもので、`fusion_fusion.result.txt`の各行の変異を一意に特定するための情報です。`<source>`カラムは各行の変異のソース値が出力されます。この`star.chimeric.trace.txt`と`fusion_fusion.result.txt`の内容を組み合わせることにより、`fusion_fusion.result.traced.txt`を生成します。

なお、各変異のソース情報を追跡するために、`star.chimeric.tmp[12].txt`から`star.chimeric.clustered.filt2.txt`までのリードIDを変更しています。`star.chimeric.tmp1.txt`に含まれる各行のリードIDには[`@Chimeric`というサフィックスが付与され](https://github.com/chrovis-genomon/fusionfusion/blob/dbd2e50dd3950d5cac0c84d9b06e373194b9d1d9/fusionfusion/run.py#L159)、`star.chimeric.tmp2.txt`に含まれる各行のリードIDには[`@SJ`というサフィックスが付与されます](https://github.com/chrovis-genomon/fusionfusion/blob/dbd2e50dd3950d5cac0c84d9b06e373194b9d1d9/fusionfusion/run.py#L182)。これらのリードIDに対する変更は後段の処理に影響を与えることはありません。