### PR TITLE
STARのSAMファイルパース時エラーの修正

### DIFF
--- a/fusionfusion/parseJunctionInfo.py
+++ b/fusionfusion/parseJunctionInfo.py
@@ -491,7 +491,7 @@ def getFusInfo_STAR(juncLine, source=None):
             if clipLen_SA > expected_clipLen_SA:
                 surPlus_start = readLength_primary - clipLen_primary
                 surPlus_end = surPlus_start + clipLen_SA - expected_clipLen_SA
-                juncSurplus = read.seq[surPlus_start:surPlus_end]
+                juncSurplus = F[9][surPlus_start:surPlus_end]
 
             # reorder by the chromosome position and print
             if juncChr_primary < juncChr_SA or juncChr_primary == juncChr_SA and juncPos_primary <= juncPos_SA:
@@ -563,7 +563,7 @@ def getFusInfo_STAR(juncLine, source=None):
             if clipLen_SA > expected_clipLen_SA:
                 surPlus_end = clipLen_primary # this is right
                 surPlus_start = surPlus_end - (clipLen_SA - expected_clipLen_SA)
-                juncSurplus = read.seq[surPlus_start:surPlus_end]
+                juncSurplus = F[9][surPlus_start:surPlus_end]
 
             # reorder by the chromosome position and print
             if juncChr_primary < juncChr_SA or juncChr_primary == juncChr_SA and juncPos_primary <= juncPos_SA:


### PR DESCRIPTION
STARから得られる結果のSAMファイルからアライメントをパースする際に以下のようなエラーが発生することがあります：

```python
Traceback (most recent call last):
  File "/usr/local/bin/fusionfusion", line 11, in <module>
    load_entry_point('fusionfusion==0.5.0', 'console_scripts', 'fusionfusion')()
  File "build/bdist.linux-x86_64/egg/fusionfusion/__init__.py", line 10, in main
  File "build/bdist.linux-x86_64/egg/fusionfusion/run.py", line 149, in fusionfusion_main
  File "build/bdist.linux-x86_64/egg/fusionfusion/parseJunctionInfo.py", line 596, in parseJuncInfo_STAR
  File "build/bdist.linux-x86_64/egg/fusionfusion/parseJunctionInfo.py", line 566, in getFusInfo_STAR
NameError: global name 'read' is not defined
```

これは、SAMファイルから各行のアライメントの塩基配列を読み込む際、`F[9]`(SAMファイルの10カラム目)ではなく`read.seq`(pysamを使っている場合の塩基配列の取得方法)を使っていることが原因となっており、未定義変数である`read`へのアクセスがエラーを引き起こしています。

このエラーは特に、ブレークポイントの間にinserted sequenceが検出された場合に発生するようですが、実運用時でもエラーが発生するケースはあまり多くなく比較的発生しにくい事象と思われます。

このPRでは、`read.seq`を`F[9]`に直すことでエラーを修正しています。
