### PR TITLE
STARのSAMファイルパース時エラーの修正 (修正版)

### DIFF
--- a/fusionfusion/parseJunctionInfo.py
+++ b/fusionfusion/parseJunctionInfo.py
@@ -391,6 +391,7 @@ def getFusInfo_STAR(juncLine, source=None):
     # collect information about primary junction read and its pair read
     right_clipping_primary = 0
     left_clipping_primary = 0
+    seq_primary = ""
     cigar_primary = ""
     readLength_primary = 0
     readID_primary = ""
@@ -407,6 +408,7 @@ def getFusInfo_STAR(juncLine, source=None):
             dir_primary = ("-" if flags[4] == "1" else "+")
             mq_primary = F[4]
             coverRegion_primary = cigar_utils.getCoverRegion(F[2], F[3], F[5])
+            seq_primary = F[9]
             readLength_primary = len(F[9])
             endPos_primary = cigar_utils.getEndPos(pos_primary, F[5])
             readID_primary = "{qname}/{read}{suffix}".format(
@@ -491,7 +493,7 @@ def getFusInfo_STAR(juncLine, source=None):
             if clipLen_SA > expected_clipLen_SA:
                 surPlus_start = readLength_primary - clipLen_primary
                 surPlus_end = surPlus_start + clipLen_SA - expected_clipLen_SA
-                juncSurplus = read.seq[surPlus_start:surPlus_end]
+                juncSurplus = seq_primary[surPlus_start:surPlus_end]
 
             # reorder by the chromosome position and print
             if juncChr_primary < juncChr_SA or juncChr_primary == juncChr_SA and juncPos_primary <= juncPos_SA:
@@ -563,7 +565,7 @@ def getFusInfo_STAR(juncLine, source=None):
             if clipLen_SA > expected_clipLen_SA:
                 surPlus_end = clipLen_primary # this is right
                 surPlus_start = surPlus_end - (clipLen_SA - expected_clipLen_SA)
-                juncSurplus = read.seq[surPlus_start:surPlus_end]
+                juncSurplus = seq_primary[surPlus_start:surPlus_end]
 
             # reorder by the chromosome position and print
             if juncChr_primary < juncChr_SA or juncChr_primary == juncChr_SA and juncPos_primary <= juncPos_SA:


### PR DESCRIPTION
#16 の修正版のプルリクエストになります。

基本的には #16 と同様に、insertionを持つ融合遺伝子を検出した場合に発生するエラーを修正する変更です。
前回の修正では、`read.seq` という未定義変数の参照を避け、 `F[9]` (SAMファイルのSEQカラムに当たる)からinsertionの配列を抽出するようにしてエラーを修正しようしていました。

しかし、前回の修正ではアライメントの並びによっては正しいアライメントからinsertion配列を抽出できない場合がありました。具体的には、同一QNAMEを持つプライマリ、サプリメンタリ、およびそれらのペアからなるアライメントの3つ組が、入力SAMファイル中で、

```
プライマリ
サプリメンタリ
ペア
```

もしくは、

```
サプリメンタリ
プライマリ
ペア
```

の順に並んでいる場合、ペアのアライメントから誤ってinsertion配列を抽出してしまう問題がありました。

このプルリクエストでは、insertion配列を必ずプライマリのアライメントから抽出するように変更することで、このアライメントの順序依存性による問題を解決します。
