### PR TITLE
Dockerfileの調整

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN wget -q https://github.com/samtools/htslib/releases/download/1.15/htslib-1.1
 
 RUN pip3 install pysam==0.19.1
 RUN pip3 install annot-utils==0.3.1
-RUN pip3 install chimera_utils==0.6.0
 
 RUN cd  /usr/local/bin && \
     wget http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/blat/blat && \
@@ -36,3 +35,5 @@ RUN cd  /usr/local/bin && \
 RUN git clone https://github.com/Genomon-Project/fusionfusion.git && \
     cd fusionfusion && \
     python3 setup.py build install
+
+RUN pip3 install chimera_utils==0.6.0


### PR DESCRIPTION
このプルリクエストはfusionfusionのDockerfileを以下の3点について変更します。

## BLATのビルド時の除外

#11 の修正により、fusionfusionの実行についてBLATが必須ではなくなりました。
以下のように、Dockerイメージのビルド時にビルド変数`NO_BLAT`を指定することにより、ビルド後のDockerイメージからBLATを除外できるようにしています：

```console
docker build --build-arg NO_BLAT=true ...
```

## ローカルのソースコードの利用

現状のDockerfileの記述では、ビルド時にGitHub上のリポジトリ https://github.com/Genomon-Project/fusionfusion.git からコードをクローンします。この構成では、たとえばローカル環境で修正したコードを含むDockerイメージのビルド等がしづらくなっています。

このプルリクエストでは、ローカルのコードを`COPY`することでコードを取り回しやすくしています。

## `chimera_utils`のインストールタイミングの変更

現状のDockerfileの記述では、`chimera_utils`のインストール(`pip3 install chimera_utils==0.6.0`)後に`fusionfusion`のインストール(`python3 setup.py build install`)をしています。

しかし、`chimera_utils`は依存ライブラリとして`fusionfusion`を利用しているため、`chimera_utils`をインストールした時点で、PYPI (pip)に登録されている最新バージョンの`fusionfusion`(2022/7/14現在で`0.5.0`)が自動的にインストールされます。これによって、`chimera_utils`のインストール後の`fusionfusion`のインストールが阻害され、意図しない「古い」バージョンの`fusionfusion`がインストールされた状態になる可能性があります。

このプルリクエストでは、`fusionfusion`のインストール後に`chimera_utils`をインストールすることで、意図したリビジョンの`fusionfusion`がインストールされることを保証します。